### PR TITLE
Integrate clustering algorithm into frontend

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -21,6 +21,7 @@
                     Mochila</a></li>
             <li class="nav-item"><a href="#" class="nav-link text-white" data-target="backprop">Backpropagation</a></li>
             <li class="nav-item"><a href="#" class="nav-link text-white" data-target="mobilenet">MobileNetV2</a></li>
+            <li class="nav-item"><a href="#" class="nav-link text-white" data-target="clustering">Clustering</a></li>
         </ul>
     </nav>
     <div class="sections">
@@ -92,21 +93,17 @@
                     </div>
                 </div>
                 <div class="col">
-                    <div class="card h-100 shadow-sm opcion-inicio" data-target="mobilenet">
+                    <div class="card h-100 shadow-sm opcion-inicio" data-target="clustering">
                         <div class="card-body">
-                             <div class="icon-opcion">
-                                 <svg width="36" height="36" viewBox="0 0 36 36" fill="none"
-                                    xmlns="http://www.w3.org/2000/svg">
-                                    <path
-                                        d="M28.9748 13.5009C27.4327 13.5675 25.96 14.1607 24.8023 15.1815C23.6446 16.2023 22.8717 17.5891 22.6125 19.1107C22.3533 20.6322 22.6235 22.1967 23.3779 23.5432C24.1324 24.8898 25.3256 25.937 26.7587 26.5105C26.3506 28.0437 25.4155 29.3842 24.1174 30.2965C22.8193 31.2089 21.2413 31.6348 19.6605 31.4994C17.9514 31.3185 16.3718 30.5049 15.2322 29.2185C14.0925 27.9321 13.4752 26.2659 13.5016 24.5475V20.0479C16.0463 19.5284 18.3328 18.1445 19.9732 16.131C21.6135 14.1175 22.5066 11.5984 22.5009 9.00124V4.50159C22.5009 3.30822 22.0268 2.16371 21.183 1.31987C20.3391 0.476021 19.1946 0.00195313 18.0012 0.00195312H16.8763C16.2796 0.00195312 15.7074 0.238988 15.2855 0.660911C14.8636 1.08283 14.6265 1.65508 14.6265 2.25177C14.6265 2.84846 14.8636 3.42071 15.2855 3.84264C15.7074 4.26456 16.2796 4.50159 16.8763 4.50159H18.0012V8.80438C18.022 10.5078 17.41 12.1583 16.2836 13.4364C15.1573 14.7144 13.5968 15.5291 11.9042 15.7226C10.967 15.8136 10.0211 15.7075 9.12726 15.4111C8.23346 15.1147 7.41158 14.6345 6.71444 14.0015C6.01731 13.3685 5.46035 12.5966 5.07938 11.7354C4.6984 10.8742 4.50184 9.9429 4.50233 9.00124V4.50159H5.62724C6.22393 4.50159 6.79618 4.26456 7.2181 3.84264C7.64002 3.42071 7.87706 2.84846 7.87706 2.25177C7.87706 1.65508 7.64002 1.08283 7.2181 0.660911C6.79618 0.238988 6.22393 0.00195312 5.62724 0.00195312H4.50233C3.30895 0.00195313 2.16445 0.476021 1.3206 1.31987C0.476754 2.16371 0.00268578 3.30822 0.00268578 4.50159V9.00124C0.0021565 11.5945 0.897627 14.1083 2.53754 16.1172C4.17746 18.1261 6.4611 19.5067 9.00197 20.0254V24.48C9.00197 30.712 14.1034 36.0497 20.3467 35.9991C22.9794 35.9744 25.5201 35.0271 27.5263 33.322C29.5325 31.617 30.877 29.2623 31.3258 26.668C32.8792 26.1667 34.1983 25.1196 35.0388 23.7205C35.8794 22.3213 36.1845 20.665 35.8976 19.0582C35.6107 17.4514 34.7512 16.003 33.4784 14.9812C32.2056 13.9595 30.6056 13.4335 28.9748 13.5009ZM29.2504 22.5002C28.8054 22.5002 28.3704 22.3682 28.0004 22.121C27.6304 21.8738 27.3421 21.5224 27.1718 21.1113C27.0015 20.7002 26.957 20.2478 27.0438 19.8114C27.1306 19.375 27.3448 18.9741 27.6595 18.6595C27.9741 18.3448 28.375 18.1306 28.8114 18.0437C29.2479 17.9569 29.7002 18.0015 30.1113 18.1718C30.5224 18.3421 30.8738 18.6304 31.121 19.0004C31.3682 19.3704 31.5002 19.8054 31.5002 20.2503C31.5002 20.847 31.2631 21.4193 30.8412 21.8412C30.4193 22.2631 29.847 22.5002 29.2504 22.5002Z"
-                                        fill="#5FA8D3" />
-                                </svg>
+                            <div class="icon-opcion">
+                                <img src="/static/image/Machine Learning 1.svg" alt="Clustering">
                             </div>
-                            <h5 class="card-title"> Clasificación de imágenes con Transfer Learning.</h5>
-                            <p class="card-text">Clasifica emociones humanas a partir de imágenes faciales mediante un modelo entrenado con Transfer Learning.</p>
-                            <button class="opcion-button" data-target="mobilenet"> Ver proyecto</button>
+                            <h5 class="card-title">Clustering</h5>
+                            <p class="card-text">Agrupa datos y analiza la similitud entre clientes.</p>
+                            <button class="opcion-button" data-target="clustering">Ver proyecto</button>
                         </div>
                     </div>
+                </div>
                 </div>
                  <div class="col">
                     <div class="card h-100 shadow-sm opcion-inicio" data-target="mobilenet">
@@ -230,6 +227,17 @@
                     </div>
                 </form>
                 <div id="mn_res"></div>
+            </section>
+            <section id="clustering" class="content-section">
+                <h3>Clustering</h3>
+                <form id="form-clustering" class="mb-3">
+                    <div class="mb-3">
+                        <label class="form-label">Archivo CSV</label>
+                        <input type="file" class="form-control" id="clust_file" accept=".csv">
+                    </div>
+                    <button type="submit" class="btn btn-primary">Ejecutar</button>
+                </form>
+                <div id="clust_res"></div>
             </section>
         </div>
     </div>
@@ -387,6 +395,20 @@
             const r = await fetch('/api/mobilenet', { method: 'POST', body: fd });
             const res = await r.json();
             document.getElementById('mn_res').innerHTML = `<p><strong>Clase:</strong> ${res.label}</p><p><strong>Probabilidad:</strong> ${res.probability.toFixed(3)}</p>`;
+        });
+        // Clustering
+        document.getElementById("form-clustering").addEventListener("submit", async e => {
+            e.preventDefault();
+            const fileInput = document.getElementById("clust_file");
+            if (!fileInput.files.length) return;
+            const fd = new FormData();
+            fd.append("file", fileInput.files[0]);
+            const r = await fetch("/api/clustering", { method: "POST", body: fd });
+            const res = await r.json();
+            let html = `<p><strong>Silhouette KMeans:</strong> ${res.silhouette.kmeans.toFixed(3)}</p>`;
+            html += `<p><strong>Silhouette DBSCAN:</strong> ${res.silhouette.dbscan.toFixed(3)}</p>`;
+            html += `<p><strong>Silhouette Agglomerativo:</strong> ${res.silhouette.agglo.toFixed(3)}</p>`;
+            document.getElementById("clust_res").innerHTML = html;
         });
     </script>
 


### PR DESCRIPTION
## Summary
- add Clustering option to sidebar
- replace duplicate card with Clustering card
- add clustering section to upload CSV and see results
- add frontend logic to call `/api/clustering`

## Testing
- `python -m py_compile app/main.py clustering.py`

------
https://chatgpt.com/codex/tasks/task_e_686345b0fd9483278704d3d13c453cf5