### PR TITLE
Use Naive Bayes with scaling

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -18,7 +18,7 @@ except Exception:
     mobilenet = None
 
 from clustering import run_clustering
-from sentiment import predict_sentiment
+from sentiment import predict_sentiment, init_sentiment_model
 
 
 
@@ -26,6 +26,11 @@ app = FastAPI(title="Algoritmos Inteligentes")
 
 # Serve frontend
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
+
+@app.on_event("startup")
+async def startup_event():
+    """Pre-carga los modelos necesarios."""
+    init_sentiment_model()
 
 @app.get("/")
 def index():
@@ -200,7 +205,7 @@ async def ejecutar_mobilenet_api(file: UploadFile = File(...)):
         tmp.write(data)
         tmp_path = tmp.name
     try:
-        label, prob = mobilenet.clasificar_imagen(tmp_path)
+        label, prob = mobilenet.predecir_emocion(tmp_path)
     finally:
         os.remove(tmp_path)
     return MobileNetResponse(label=label, probability=prob)

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -21,6 +21,7 @@
                     Mochila</a></li>
             <li class="nav-item"><a href="#" class="nav-link text-white" data-target="backprop">Backpropagation</a></li>
             <li class="nav-item"><a href="#" class="nav-link text-white" data-target="mobilenet">MobileNetV2</a></li>
+            <li class="nav-item"><a href="#" class="nav-link text-white" data-target="sentiment">Análisis de Sentimiento</a></li>
             <li class="nav-item"><a href="#" class="nav-link text-white" data-target="clustering">Clustering</a></li>
         </ul>
     </nav>
@@ -232,6 +233,20 @@
                 </form>
                 <div id="mn_res"></div>
             </section>
+
+            <section id="sentiment" class="content-section">
+                <h3>Análisis de Sentimiento</h3>
+                <form id="form-sentiment" class="row g-3">
+                    <div class="col-12">
+                        <label class="form-label">Texto</label>
+                        <textarea id="sentiment_text" class="form-control" rows="3"></textarea>
+                    </div>
+                    <div class="col-12">
+                        <button type="submit" class="btn btn-primary">Analizar</button>
+                    </div>
+                </form>
+                <div id="sentiment_res"></div>
+            </section>
         </div>
     </div>
 
@@ -388,6 +403,26 @@
             const r = await fetch('/api/mobilenet', { method: 'POST', body: fd });
             const res = await r.json();
             document.getElementById('mn_res').innerHTML = `<p><strong>Clase:</strong> ${res.label}</p><p><strong>Probabilidad:</strong> ${res.probability.toFixed(3)}</p>`;
+        });
+
+        // Sentiment
+        document.getElementById('form-sentiment').addEventListener('submit', async e => {
+            e.preventDefault();
+            const text = document.getElementById('sentiment_text').value.trim();
+            if (!text) return;
+            const body = { text };
+            const r = await fetch('/api/sentiment', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body)
+            });
+            if (!r.ok) {
+                const text = await r.text();
+                document.getElementById('sentiment_res').innerHTML = `<p class="text-danger">Error: ${text}</p>`;
+                return;
+            }
+            const res = await r.json();
+            document.getElementById('sentiment_res').innerHTML = `<p><strong>Sentimiento:</strong> ${res.sentiment}</p>`;
         });
     </script>
 

--- a/naivebayes.py
+++ b/naivebayes.py
@@ -1,10 +1,12 @@
 import pandas as pd
-from sklearn.preprocessing import LabelEncoder
+from sklearn.preprocessing import LabelEncoder, StandardScaler
 from sklearn.impute import SimpleImputer
 from sklearn.model_selection import train_test_split
 from sklearn.naive_bayes import GaussianNB
 from sklearn.datasets import load_digits
+from sklearn.pipeline import Pipeline
 from PIL import Image
+import numpy as np
 
 def entrenar_modelo(
     url: str = 'https://github.com/YBIFoundation/Dataset/raw/main/Cancer.csv',
@@ -13,7 +15,8 @@ def entrenar_modelo(
     imputer_strategy: str = 'mean'
 ):
     logs = []
-    cancer = pd.read_csv(url)
+    # Algunos datasets públicos pueden no estar en UTF-8
+    cancer = pd.read_csv(url, encoding="latin1")
     logs.append(f"Cargado CSV con {cancer.shape[0]} filas y {cancer.shape[1]} columnas")
 
     # Codificar diagnóstico
@@ -47,10 +50,13 @@ def entrenar_modelo(
     logs.append(f"Split train/test: test_size={test_size}, random_state={random_state}")
     logs.append(f"  → Train: {X_train.shape}, Test: {X_test.shape}")
 
-    # Entrenamiento
-    model = GaussianNB()
+    # Entrenamiento con escalado de features
+    model = Pipeline([
+        ("scaler", StandardScaler()),
+        ("nb", GaussianNB()),
+    ])
     model.fit(X_train, y_train)
-    logs.append("Modelo GaussianNB entrenado")
+    logs.append("Modelo GaussianNB entrenado con escalado")
 
     # Precisión
     accuracy = model.score(X_test, y_test)
@@ -71,7 +77,10 @@ def _load_digits_model():
         X_train, X_test, y_train, y_test = train_test_split(
             digits.data, digits.target, test_size=0.2, random_state=42
         )
-        model = GaussianNB()
+        model = Pipeline([
+            ("scaler", StandardScaler()),
+            ("nb", GaussianNB()),
+        ])
         model.fit(X_train, y_train)
         _digits_model = model
     return _digits_model

--- a/sentiment.py
+++ b/sentiment.py
@@ -26,8 +26,10 @@ def init_sentiment_model() -> None:
                     tokenizer=MODEL_NAME,
                 )
             except Exception as e:
-                raise RuntimeError(
-                    f"Error al cargar el modelo de sentimiento '{MODEL_NAME}': {e}"
+                # Propagar como HTTPException para que FastAPI devuelva JSON
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Error al cargar el modelo de sentimiento '{MODEL_NAME}': {e}"
                 )
 
 


### PR DESCRIPTION
## Summary
- revert LogisticRegression back to GaussianNB
- scale features via `StandardScaler` using a scikit-learn pipeline
- enable emotion detection with MobileNetV2 trained on provided dataset
- handle dataset encoding issues for Naive Bayes
- make sentiment model errors JSON friendly and report them to the frontend

## Testing
- `python -m py_compile mobilenet.py app/main.py naivebayes.py sentiment.py`

------
https://chatgpt.com/codex/tasks/task_e_68636a6dcfa08327988d71e8eca31013