### PR TITLE
Clean code by removing comments

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -20,8 +20,6 @@ from sentiment import predict_sentiment, init_sentiment_model
 
 
 app = FastAPI(title="Algoritmos Inteligentes")
-
-# Serve frontend
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
 
 @app.on_event("startup")
@@ -32,26 +30,21 @@ async def startup_event():
 @app.get("/")
 def index():
     return FileResponse("app/static/index.html")
-
-# ---- Naive Bayes ----
-# ---- Naive Bayes Mejorado ----
 class NBTrainRequest(BaseModel):
     test_size: float = 0.2
     random_state: int = 22
     imputer_strategy: str = "mean"
-    # Nuevos parámetros para el algoritmo mejorado
     use_feature_selection: bool = True
-    feature_selection_method: str = "mutual_info"  # "mutual_info", "f_classif", "rfe"
+    feature_selection_method: str = "mutual_info"
     k_features: int = 15
     use_scaling: bool = True
-    scaling_method: str = "robust"  # "robust" o "standard"
+    scaling_method: str = "robust"
     cv_folds: int = 5
 
 class NBTrainResponse(BaseModel):
     accuracy: float
     features: List[str]
     logs: List[str]
-    # Nuevas métricas médicas
     cv_accuracy: Optional[float] = None
     sensitivity: Optional[float] = None
     specificity: Optional[float] = None
@@ -62,7 +55,6 @@ class NBPredictRequest(BaseModel):
 
 class NBPredictResponse(BaseModel):
     diagnosis: str
-    # Nuevos campos para predicción mejorada
     confidence: Optional[float] = None
     probabilities: Optional[Dict[str, float]] = None
 
@@ -84,8 +76,6 @@ class ClusteringResponse(BaseModel):
     silhouette: ClusteringSilhouette
     labels: ClusteringLabels
     pca: List[List[float]]
-
-# Modelos Pydantic
 class SentimentRequest(BaseModel):
     text: str
 
@@ -97,11 +87,8 @@ nb_state = {"model": None, "le": None, "features": None}
 
 @app.post("/api/clustering", response_model=ClusteringResponse)
 async def clustering_endpoint(file: UploadFile = File(...)):
-    # Aceptamos solo CSV
     if file.content_type != "text/csv":
         raise HTTPException(status_code=400, detail="Formato de archivo no soportado, se espera un CSV")
-
-    # Guardar temporalmente
     data = await file.read()
     with tempfile.NamedTemporaryFile(delete=False, suffix=".csv") as tmp:
         tmp.write(data)
@@ -118,7 +105,6 @@ async def clustering_endpoint(file: UploadFile = File(...)):
 def train_nb(req: NBTrainRequest):
     """Entrenar modelo de detección de cáncer con algoritmo mejorado."""
     try:
-        # Llamar al algoritmo mejorado
         result = naivebayes.entrenar_modelo(
             test_size=req.test_size,
             random_state=req.random_state,
@@ -132,7 +118,6 @@ def train_nb(req: NBTrainRequest):
         )
         
         if len(result) == 6:
-            # Nuevo formato con pipeline_objects
             model, le, feats, acc, logs, pipeline_objects = result
             nb_state.update({
                 "model": model, 
@@ -140,8 +125,6 @@ def train_nb(req: NBTrainRequest):
                 "features": feats,
                 "pipeline_objects": pipeline_objects
             })
-            
-            # Extraer métricas adicionales de los logs
             cv_accuracy = None
             sensitivity = None
             specificity = None
@@ -170,7 +153,6 @@ def train_nb(req: NBTrainRequest):
                 auc_score=auc_score
             )
         else:
-            # Formato anterior (compatibilidad)
             model, le, feats, acc, logs = result
             nb_state.update({"model": model, "le": le, "features": feats, "pipeline_objects": None})
             return NBTrainResponse(accuracy=acc, features=feats, logs=logs)
@@ -185,7 +167,6 @@ def predict_nb(req: NBPredictRequest):
         raise HTTPException(status_code=400, detail="Modelo no entrenado")
     
     try:
-        # Si tenemos pipeline_objects, usar predicción mejorada
         if nb_state["pipeline_objects"] is not None:
             result = naivebayes.predecir_con_pipeline(
                 nb_state["model"],
@@ -199,7 +180,6 @@ def predict_nb(req: NBPredictRequest):
                 probabilities=result["probabilities"]
             )
         else:
-            # Predicción tradicional (compatibilidad)
             arr = np.array(req.values).reshape(1, -1)
             pred = nb_state["model"].predict(arr)[0]
             diag = nb_state["le"].inverse_transform([pred])[0]
@@ -223,14 +203,10 @@ async def nb_from_image(file: UploadFile = File(...)):
     finally:
         os.remove(tmp_path)
     return NBImageResponse(label=label, probability=prob)
-
-# Endpoint en main.py
 @app.post("/api/sentiment", response_model=SentimentResponse)
 async def sentiment_endpoint(req: SentimentRequest):
     resultado = predict_sentiment(req.text)
     return SentimentResponse(sentiment=resultado)
-
-# ---- Mochila ----
 class Objeto(BaseModel):
     nombre: str
     peso: float
@@ -252,8 +228,6 @@ def ejecutar_mochila(req: MochilaRequest):
     mochila.CAPACIDAD_MAXIMA = req.capacidad
     sel, peso, val, hist = mochila.ejecutar_genetico()
     return MochilaResponse(seleccion=sel, peso=peso, valor=val, historia=hist)
-
-# ---- Backpropagation ----
 class BackpropRequest(BaseModel):
     inputs: List[List[float]]
     outputs: List[List[float]]
@@ -273,8 +247,6 @@ def ejecutar_backprop(req: BackpropRequest):
         hidden_neurons=2,
     )
     return BackpropResponse(result=np.round(out, 4).tolist())
-
-# ---- MobileNetV2 ----
 
 class MobileNetResponse(BaseModel):
     label: str

--- a/clustering.py
+++ b/clustering.py
@@ -26,33 +26,25 @@ def run_clustering(
     Ejecuta clustering sobre un CSV de clientes.
     Devuelve puntuaciones de silueta, etiquetas y componentes PCA.
     """
-    # Cargar datos
     df = pd.read_csv(file_path)
 
-    # Codificar columna categórica si existe
     if 'Categoria_Favorita' in df.columns:
         df = pd.get_dummies(df, columns=['Categoria_Favorita'])
 
-    # Estandarizar
     X_scaled = StandardScaler().fit_transform(df.values)
 
-    # Reducir dimensionalidad para visualización
     pca = PCA(n_components=2)
     X_pca = pca.fit_transform(X_scaled)
 
-    # K-Means
     kmeans = KMeans(n_clusters=n_clusters, random_state=42)
     km_labels = kmeans.fit_predict(X_scaled)
 
-    # DBSCAN
     dbscan = DBSCAN(eps=eps, min_samples=min_samples)
     db_labels = dbscan.fit_predict(X_scaled)
 
-    # Agrupamiento Jerárquico
     agglo = AgglomerativeClustering(n_clusters=n_clusters)
     ag_labels = agglo.fit_predict(X_scaled)
 
-    # Coeficientes de silueta
     sil_km = safe_silhouette(X_scaled, km_labels)
     sil_db = safe_silhouette(X_scaled, db_labels)
     sil_ag = safe_silhouette(X_scaled, ag_labels)

--- a/mobilenet.py
+++ b/mobilenet.py
@@ -25,8 +25,6 @@ def ejecutar_mobilenet(path_zip, epochs, batch_size, learning_rate, *, save_path
     if not os.path.isdir(work_dir):
         with zipfile.ZipFile(path_zip, 'r') as z:
             z.extractall(work_dir)
-
-    # Preparar datasets
     train_ds = tf.keras.preprocessing.image_dataset_from_directory(
         work_dir,
         validation_split=0.2,
@@ -43,39 +41,25 @@ def ejecutar_mobilenet(path_zip, epochs, batch_size, learning_rate, *, save_path
         image_size=(224, 224),
         batch_size=batch_size
     )
-
-    # Obtener número de clases
     num_classes = len(train_ds.class_names)
-
-    # Prefetch
     AUTOTUNE = tf.data.AUTOTUNE
     train_ds = train_ds.prefetch(buffer_size=AUTOTUNE)
     val_ds = val_ds.prefetch(buffer_size=AUTOTUNE)
-
-    # Cargar MobileNetV2 base
     base_model = MobileNetV2(include_top=False, input_shape=(224, 224, 3), weights='imagenet')
     base_model.trainable = False
-
-    # Cabeza personalizada
     inputs = layers.Input(shape=(224, 224, 3))
     x = base_model(inputs, training=False)
     x = layers.GlobalAveragePooling2D()(x)
     x = layers.Dropout(0.2)(x)
     outputs = layers.Dense(num_classes, activation='softmax')(x)
     model = models.Model(inputs, outputs)
-
-    # Compilar
     opt = optimizers.Adam(learning_rate=learning_rate)
     model.compile(optimizer=opt, loss='sparse_categorical_crossentropy', metrics=['accuracy'])
-
-    # Entrenar
     history = model.fit(
         train_ds,
         validation_data=val_ds,
         epochs=epochs
     )
-
-    # Evaluar
     eval_loss, eval_acc = model.evaluate(val_ds)
     eval_metrics = {'loss': eval_loss, 'accuracy': eval_acc}
 

--- a/mobilenet_module.py
+++ b/mobilenet_module.py
@@ -1,4 +1,3 @@
-# mobilenet_module.py
 import os
 from typing import Tuple, List
 import numpy as np
@@ -38,12 +37,10 @@ def load_labels(labels_path: str = None) -> List[str]:
         return [line.strip() for line in f if line.strip()]
 
 
-# Inicializar modelo y etiquetas globalmente
 global_model = load_mobilenet_model()
 try:
     global_labels = load_labels()
 except FileNotFoundError:
-    # Clases por defecto si no hay labels.txt
     global_labels = [
         "surprise", "fear", "happy",
         "neutral", "sad", "angry", "disgust"
@@ -55,22 +52,15 @@ def classify_image(img_path: str) -> Tuple[str, float]:
     Clasifica la imagen usando el modelo MobileNetV2 personalizado.
     Devuelve la etiqueta y la probabilidad asociada.
     """
-    # Cargar y preprocesar imagen
     img = image.load_img(img_path, target_size=(224, 224))
     x = image.img_to_array(img)
     x = np.expand_dims(x, axis=0)
-    # Si tu modelo requiere normalización, descomenta:
-    # from tensorflow.keras.applications.mobilenet_v2 import preprocess_input
-    # x = preprocess_input(x)
 
-    # Inferencia
     preds_raw = global_model.predict(x)
     if preds_raw is None:
         raise RuntimeError("Falló la predicción: preds_raw es None")
-    # Aplanar vector de predicciones
     preds = preds_raw.flatten()
 
-    # Seleccionar la clase más probable
     idx = int(np.argmax(preds))
     label = global_labels[idx] if idx < len(global_labels) else str(idx)
     prob = float(preds[idx])

--- a/naivebayes.py
+++ b/naivebayes.py
@@ -34,30 +34,18 @@ def entrenar_modelo(
     - Manejo avanzado de outliers
     """
     logs = []
-    
-    # Carga de datos con validación
     try:
         cancer = pd.read_csv(url)
         logs.append(f"✓ Cargado CSV con {cancer.shape[0]} filas y {cancer.shape[1]} columnas")
     except Exception as e:
         logs.append(f"✗ Error cargando datos: {str(e)}")
         return None, None, None, 0.0, logs
-
-    # Análisis inicial de datos
     logs.append(f"• Distribución de diagnósticos: {cancer['diagnosis'].value_counts().to_dict()}")
-    
-    # Codificar diagnóstico (M=1 maligno, B=0 benigno)
     le = LabelEncoder()
     cancer['diagnosis'] = le.fit_transform(cancer['diagnosis'])
-    
-    # Verificar que M sea 1 (maligno) y B sea 0 (benigno) para interpretabilidad médica
     class_mapping = dict(zip(le.classes_, le.transform(le.classes_)))
     logs.append(f"• Codificación diagnóstico: {class_mapping}")
-    
-    # Preparación de features con limpieza mejorada
     X = cancer.drop(columns=['id', 'diagnosis'])
-    
-    # Eliminar columnas problemáticas
     cols_to_drop = []
     for col in X.columns:
         if col.startswith('Unnamed') or X[col].isna().all() or X[col].nunique() <= 1:
@@ -69,8 +57,6 @@ def entrenar_modelo(
     
     y = cancer['diagnosis']
     logs.append(f"• Features iniciales: {len(X.columns)} columnas")
-    
-    # Detección y tratamiento de outliers usando IQR
     numeric_cols = X.select_dtypes(include=[np.number]).columns
     outlier_counts = {}
     
@@ -84,45 +70,33 @@ def entrenar_modelo(
         outliers = ((X[col] < lower_bound) | (X[col] > upper_bound)).sum()
         if outliers > 0:
             outlier_counts[col] = outliers
-            # Winsorizing: limitar valores extremos
             X[col] = X[col].clip(lower=lower_bound, upper=upper_bound)
     
     if outlier_counts:
         logs.append(f"• Outliers tratados en {len(outlier_counts)} columnas: {sum(outlier_counts.values())} valores")
-    
-    # Imputación inteligente
     imputer = SimpleImputer(strategy=imputer_strategy)
     X_imp = imputer.fit_transform(X)
     logs.append(f"• Imputación ({imputer_strategy}) aplicada")
-    
-    # Reconstruir DataFrame
     X = pd.DataFrame(X_imp, columns=X.columns)
-    
-    # Escalado de características (importante para Naive Bayes con features de diferentes escalas)
     scaler = None
     if use_scaling:
         if scaling_method == 'robust':
-            scaler = RobustScaler()  # Mejor para datos médicos con outliers
+            scaler = RobustScaler()
         else:
             scaler = StandardScaler()
         
         X_scaled = scaler.fit_transform(X)
         X = pd.DataFrame(X_scaled, columns=X.columns)
         logs.append(f"• Escalado ({scaling_method}) aplicado")
-    
-    # Selección de características optimizada para datos médicos
     selected_features = X.columns.tolist()
     feature_selector = None
     
     if use_feature_selection and len(X.columns) > k_features:
         if feature_selection_method == 'mutual_info':
-            # Información mutua: mejor para relaciones no lineales
             selector = SelectKBest(score_func=mutual_info_classif, k=k_features)
         elif feature_selection_method == 'f_classif':
-            # F-test: mejor para relaciones lineales
             selector = SelectKBest(score_func=f_classif, k=k_features)
-        else:  # RFE
-            # Eliminación recursiva con Naive Bayes
+        else:
             nb_temp = GaussianNB()
             selector = RFE(estimator=nb_temp, n_features_to_select=k_features)
         
@@ -133,8 +107,6 @@ def entrenar_modelo(
         X = pd.DataFrame(X_selected, columns=selected_features)
         feature_selector = selector
         logs.append(f"• Selección de características ({feature_selection_method}): {len(selected_features)} features")
-    
-    # Split estratificado para mantener proporción de clases
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, test_size=test_size, random_state=random_state, stratify=y
     )
@@ -142,44 +114,29 @@ def entrenar_modelo(
     train_dist = pd.Series(y_train).value_counts().to_dict()
     test_dist = pd.Series(y_test).value_counts().to_dict()
     logs.append(f"• Split estratificado - Train: {train_dist}, Test: {test_dist}")
-    
-    # Entrenamiento del modelo optimizado
-    # Para datos médicos, usar var_smoothing para evitar overfitting
-    model = GaussianNB(var_smoothing=1e-9)  # Valor optimizado para datos médicos
+    model = GaussianNB(var_smoothing=1e-9)
     model.fit(X_train, y_train)
     logs.append("• Modelo GaussianNB entrenado con suavizado optimizado")
-    
-    # Evaluación completa con métricas médicas
     accuracy = model.score(X_test, y_test)
-    
-    # Validación cruzada estratificada
     cv = StratifiedKFold(n_splits=cv_folds, shuffle=True, random_state=random_state)
     cv_scores = cross_val_score(model, X_train, y_train, cv=cv, scoring='accuracy')
     cv_mean = cv_scores.mean()
     cv_std = cv_scores.std()
-    
-    # Predicciones para métricas adicionales
     y_pred = model.predict(X_test)
-    y_pred_proba = model.predict_proba(X_test)[:, 1]  # Probabilidad clase positiva (maligno)
-    
-    # Métricas específicas para diagnóstico médico
+    y_pred_proba = model.predict_proba(X_test)[:, 1]
     try:
         auc_score = roc_auc_score(y_test, y_pred_proba)
         logs.append(f"• AUC-ROC: {auc_score:.4f}")
     except:
         auc_score = 0.0
         logs.append("• AUC-ROC: No calculable")
-    
-    # Reporte de clasificación
     class_report = classification_report(y_test, y_pred, 
                                        target_names=['Benigno', 'Maligno'], 
                                        output_dict=True)
-    
-    # Métricas críticas para diagnóstico médico
-    sensitivity = class_report['Maligno']['recall']  # Sensibilidad (recall para malignos)
-    specificity = class_report['Benigno']['recall']  # Especificidad (recall para benignos)
-    ppv = class_report['Maligno']['precision']       # Valor predictivo positivo
-    npv = class_report['Benigno']['precision']       # Valor predictivo negativo
+    sensitivity = class_report['Maligno']['recall']
+    specificity = class_report['Benigno']['recall']
+    ppv = class_report['Maligno']['precision']
+    npv = class_report['Benigno']['precision']
     
     logs.append(f"• Precisión test: {accuracy:.4f}")
     logs.append(f"• Validación cruzada: {cv_mean:.4f} ± {cv_std:.4f}")
@@ -187,20 +144,14 @@ def entrenar_modelo(
     logs.append(f"• Especificidad (detectar benignos): {specificity:.4f}")
     logs.append(f"• Valor predictivo positivo: {ppv:.4f}")
     logs.append(f"• Valor predictivo negativo: {npv:.4f}")
-    
-    # Matriz de confusión
     cm = confusion_matrix(y_test, y_pred)
     tn, fp, fn, tp = cm.ravel()
     logs.append(f"• Matriz confusión - VP:{tp}, VN:{tn}, FP:{fp}, FN:{fn}")
-    
-    # Análisis de características más importantes
     if feature_selector and hasattr(feature_selector, 'scores_'):
         feature_importance = list(zip(selected_features, feature_selector.scores_))
         feature_importance.sort(key=lambda x: x[1], reverse=True)
         top_features = [f"{feat}({score:.2f})" for feat, score in feature_importance[:5]]
         logs.append(f"• Top 5 características: {', '.join(top_features)}")
-    
-    # Guardar objetos del pipeline para predicción
     pipeline_objects = {
         'scaler': scaler,
         'feature_selector': feature_selector,
@@ -214,20 +165,13 @@ def predecir_con_pipeline(model, le, pipeline_objects, valores):
     """
     Realiza predicción usando el pipeline completo de preprocesamiento.
     """
-    # Convertir valores a DataFrame
     X = pd.DataFrame([valores], columns=pipeline_objects['selected_features'])
-    
-    # Aplicar escalado si existe
     if pipeline_objects['scaler']:
         X_scaled = pipeline_objects['scaler'].transform(X)
         X = pd.DataFrame(X_scaled, columns=X.columns)
-    
-    # Aplicar selección de características si existe
     if pipeline_objects['feature_selector']:
         X_selected = pipeline_objects['feature_selector'].transform(X)
         X = pd.DataFrame(X_selected, columns=pipeline_objects['selected_features'])
-    
-    # Predicción
     pred_proba = model.predict_proba(X)[0]
     pred_class = model.predict(X)[0]
     confidence = max(pred_proba)
@@ -242,9 +186,6 @@ def predecir_con_pipeline(model, le, pipeline_objects, valores):
             'Maligno': pred_proba[1]
         }
     }
-
-
-# --- Clasificación de imágenes (mantenido sin cambios para compatibilidad) ---
 _digits_model = None
 
 def _load_digits_model():

--- a/sentiment.py
+++ b/sentiment.py
@@ -1,13 +1,8 @@
-# sentiment.py
 import threading
 from typing import Optional
 from fastapi import HTTPException
 from transformers import pipeline, Pipeline
-
-# Nombre del modelo de Transformers
 MODEL_NAME = "pysentimiento/robertuito-sentiment-analysis"
-
-# Analizador (se cargará en startup)
 sentiment_analyzer: Optional[Pipeline] = None
 _analyzer_lock = threading.Lock()
 
@@ -26,7 +21,6 @@ def init_sentiment_model() -> None:
                     tokenizer=MODEL_NAME,
                 )
             except Exception as e:
-                # Propagar como HTTPException para que FastAPI devuelva JSON
                 raise HTTPException(
                     status_code=500,
                     detail=f"Error al cargar el modelo de sentimiento '{MODEL_NAME}': {e}"
@@ -40,8 +34,6 @@ def predict_sentiment(texto: str) -> str:
     """
     if not texto or not isinstance(texto, str):
         raise HTTPException(status_code=400, detail="Texto inválido para análisis de sentimiento.")
-
-    # Asegurar inicialización
     if sentiment_analyzer is None:
         init_sentiment_model()
 


### PR DESCRIPTION
## Summary
- remove inline comments and stray text from multiple modules
- keep functionality unchanged while improving readability

## Testing
- `python -m py_compile app/main.py backprop_module.py clustering.py mobilenet.py mobilenet_module.py mochila.py naivebayes.py sentiment.py __init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6863a22c50ec8327bd16936a291ddea2